### PR TITLE
Expose CORS Origins setting

### DIFF
--- a/schemas/reticulum.toml
+++ b/schemas/reticulum.toml
@@ -68,7 +68,7 @@ extra_scripts.extra_index_script = { "type" = "string", "default" = "", category
 extra_scripts.extra_room_script = { "type" = "string", "default" = "", category = "advanced", name = "Extra Room Script", description = "Extra Javascript to run on room pages." }
 extra_scripts.extra_scene_script = { "type" = "string", "default" = "", category = "advanced", name = "Extra Scene Script", description = "Extra Javascript to run on scene pages." }
 extra_scripts.extra_avatar_script = { "type" = "string", "default" = "", category = "advanced", name = "Extra Avatar Script", description = "Extra Javascript to run on avatar pages." }
-security.cors_origins = { "type" = "string", "default" = "*", category = "advanced", name = "Allowed CORS Origins", description = "A comma-separated list of origins for CORS access. Note this should always include your main domain and link domain." }
+security.cors_origins = { "type" = "string", "default" = "", category = "advanced", name = "Allowed CORS Origins", description = "A comma-separated list of origins for CORS access. Note this should always include your main domain and link domain." }
 uploads.host = { "type" = "string", "default" = "" }
 uploads.storage_path = { "type" = "string", "default" = "/storage" }
 uploads.quota_gb = { "type" = "number", "default" = 100 }


### PR DESCRIPTION
Some Hubs Cloud users might want more control over their CORS headers to allow for extensibility.